### PR TITLE
[FIX] 일대일 채팅방 이름 수정

### DIFF
--- a/src/modules/chat/chat.service.ts
+++ b/src/modules/chat/chat.service.ts
@@ -200,7 +200,7 @@ export class ChatService {
     // 채팅방 생성
     const roomUuid = ulid();
     const roomName =
-      name || (await this.generateRoomName(allParticipants, userUuid));
+      name || (await this.generateRoomName(allParticipants));
     const chatRoom = this.chatRoomRepository.create({
       roomUuid,
       type,


### PR DESCRIPTION
## ✅ 작업 내용
사용자가 동일한 일대일 채팅방 이름을 보게 되는 문제 발생
- generateRoomName 함수를 수정하여 모든 참여자의 닉네임이 포함된 이름을 생성
- 일관된 채팅방 이름을 위해 닉네임을 가나다순으로 정렬
## 🗣️ 공유 사항
