### PR TITLE
[REFACTOR] 인기 챌린지 조회 수정

### DIFF
--- a/src/modules/challenges/challenge.service.ts
+++ b/src/modules/challenges/challenge.service.ts
@@ -428,7 +428,6 @@ export class ChallengeService {
   /**
    * 인기 챌린지 목록
    */
-
   async getPopularChallenges() {
     const challenges = await this.challengeRepository
       .createQueryBuilder('challenge')
@@ -437,6 +436,18 @@ export class ChallengeService {
       .orderBy('CARDINALITY(challenge.participantUuid)', 'DESC')
       .limit(15)
       .getMany();
+
+    // 15개가 안되면 기간 조건을 제거하고 다시 조회
+    if (challenges.length < 15) {
+      const allChallenges = await this.challengeRepository
+        .createQueryBuilder('challenge')
+        .addSelect('CARDINALITY(challenge.participantUuid)', 'participantCount')
+        .orderBy('CARDINALITY(challenge.participantUuid)', 'DESC')
+        .limit(15)
+        .getMany();
+
+      return allChallenges;
+    }
 
     return challenges;
   }


### PR DESCRIPTION
## ✅ 작업 내용
- 기존: 최근 1개월 내 생성된 챌린지를 참여자 수 기준으로 내림차순 정렬하여 15개 조회
- 수정: 결과가 15개 미만인지 확인 → 15개 미만이면 기간 제한 없이 전체 챌린지에서 참여자 수 기준으로 15개 조회
## 🗣️ 공유 사항
